### PR TITLE
feat(homepage): changed homepage title colour

### DIFF
--- a/misc/custom.scss
+++ b/misc/custom.scss
@@ -338,4 +338,7 @@ $desktop: 960px + (2 * $gap) !default;
 	  
 .bp-hero-body {
 	background: unset;
+  .has-text-white{
+    color: #305367 !important;
+  }
 }


### PR DESCRIPTION
### Problem
previously the display text was white, which made it difficult to read the text as it was contrasted against a white background. 

### Solution
this PR adds a child selector to `bp-hero-body` (more specifically, `has-text-white`). As this css class controls the text colour, this allows us to set the text colour to the desired one